### PR TITLE
Gzoug devel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Nancy.Metadata.OpenApi [![Mit License][mit-img]][mit]
 
+This is a forked version of [Jaxelr/Nancy.Metadata.OpenApi](https://github.com/Jaxelr/Nancy.Metadata.OpenApi)
+
 _Now_ compatible to Nancy 1.X and Nancy 2.0!
 
 You can find the latest specifications of [OpenApi here](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md) 

--- a/src/Fluent/EndpointInfoExtensions.cs
+++ b/src/Fluent/EndpointInfoExtensions.cs
@@ -118,12 +118,8 @@ namespace Nancy.Metadata.OpenApi.Fluent
             {
                 Required = required,
                 Description = description,
-                Content = new Dictionary<string, SchemaRef>
-                {
-                    {
-                        contentType,
-                        new SchemaRef() { Ref = $"#/components/schemas/{GetOrSaveSchemaReference(requestType)}"}
-                    }
+                Content = new Dictionary<string, MediaTypeObject> {
+                    {contentType, new MediaTypeObject() { Schema = new SchemaRef() { Ref = $"#/components/schemas/{GetOrSaveSchemaReference(requestType)}" } } }
                 }
             };
 

--- a/src/Model/Component.cs
+++ b/src/Model/Component.cs
@@ -5,6 +5,9 @@ namespace Nancy.Metadata.OpenApi.Model
 {
     public class Component
     {
+        // TODO: Complex type properties of complex types under schemas are not properly generated
+        // TODO: Properties of Array types are not properly generated
+
         [JsonProperty("schemas")]
         public IDictionary<string, NJsonSchema.JsonSchema4> ModelDefinitions { get; set; }
     }

--- a/src/Model/MediaTypeObject.cs
+++ b/src/Model/MediaTypeObject.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Nancy.Metadata.OpenApi.Model
+{
+    // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#media-type-object
+    public class MediaTypeObject
+    {
+        [JsonProperty("schema")]        
+        public SchemaRef Schema { get; set; } 
+
+        // TODO: Add example
+        // TODO: Add examples
+        // TODO: Add encoding
+    }
+}

--- a/src/Model/OpenApiSpecification.cs
+++ b/src/Model/OpenApiSpecification.cs
@@ -22,7 +22,7 @@ namespace Nancy.Metadata.OpenApi.Model
         public Component Component { get; set; }
 
         [JsonProperty("tags")]
-        public string[] Tags { get; set; }
+        public Tag[] Tags { get; set; }
 
         [JsonProperty("externalDocs")]
         public ExternalDocumentation ExternalDocs { get; set; }

--- a/src/Model/RequestBody.cs
+++ b/src/Model/RequestBody.cs
@@ -3,13 +3,14 @@ using System.Collections.Generic;
 
 namespace Nancy.Metadata.OpenApi.Model
 {
+    // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#request-body-object
     public class RequestBody
     {
         [JsonProperty("description")]
         public string Description { get; set; }
 
         [JsonProperty("content")]
-        public Dictionary<string, SchemaRef> Content { get; set; }
+        public Dictionary<string, MediaTypeObject> Content { get; set; }
 
         [JsonProperty("required")]
         public bool Required { get; set; }

--- a/src/Model/Tag.cs
+++ b/src/Model/Tag.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace Nancy.Metadata.OpenApi.Model
+{
+    public class Tag
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("externalDocs")]
+        public ExternalDocumentation ExternalDocumentation { get; set; }
+    }
+}

--- a/src/Modules/OpenApiDocsModuleBase.cs
+++ b/src/Modules/OpenApiDocsModuleBase.cs
@@ -25,7 +25,7 @@ namespace Nancy.Metadata.OpenApi.Modules
         private readonly Server[] hosts;
         private readonly string apiBaseUrl;
         private readonly string termsOfService;
-        private readonly string[] tags;
+        private readonly Tag[] tags;
         private Contact contact;
         private License license;
         private ExternalDocumentation externalDocs;
@@ -50,7 +50,7 @@ namespace Nancy.Metadata.OpenApi.Modules
             string termsOfService = null,
             Server host = null,
             string apiBaseUrl = API_BASE_URL,
-            string[] tags = null) : this(
+            Tag[] tags = null) : this(
                     routeCacheProvider,
                     docsLocation,
                     title,
@@ -83,7 +83,7 @@ namespace Nancy.Metadata.OpenApi.Modules
             string termsOfService = null,
             Server[] hosts = null,
             string apiBaseUrl = API_BASE_URL,
-            string[] tags = null)
+            Tag[] tags = null)
         {
             this.routeCacheProvider = routeCacheProvider;
             this.title = title;

--- a/tests/Fakes/FakeModule.cs
+++ b/tests/Fakes/FakeModule.cs
@@ -12,7 +12,7 @@ namespace Nancy.Metadata.OpenApi.Tests.Fakes
         public static string ApiVersion = "v1.0";
         public static string ApiBaseUrl = "/";
         public static string TermsOfService = "blah blah blah";
-        public static string[] Tags = { "Default" };
+        public static Tag[] Tags = { new Tag() { Name = "Default" } };
 
         public FakeModule(IRouteCacheProvider routeCacheProvider) :
             base(routeCacheProvider,

--- a/tests/UnitTests/EndpointInfoTests.cs
+++ b/tests/UnitTests/EndpointInfoTests.cs
@@ -153,7 +153,7 @@ namespace Nancy.Metadata.OpenApi.Tests.UnitTests
             Assert.Equal(fakeRequest.Description, endpoint.RequestBody.Description);
             Assert.Equal(fakeRequest.Required, endpoint.RequestBody.Required);
             Assert.True(endpoint.RequestBody.Content.ContainsKey(fakeRequest.contentType));
-            Assert.Contains(nameof(FakeRequestModel), endpoint.RequestBody.Content[fakeRequest.contentType].Ref);
+            Assert.Contains(nameof(FakeRequestModel), endpoint.RequestBody.Content[fakeRequest.contentType].Schema.Ref);
         }
 
         [Fact]

--- a/tests/UnitTests/ModuleTests.cs
+++ b/tests/UnitTests/ModuleTests.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 using System.IO;
 using System.Text;
 using Xunit;
+using System.Linq;
 
 namespace Nancy.Metadata.OpenApi.Tests.UnitTests
 {
@@ -36,7 +37,11 @@ namespace Nancy.Metadata.OpenApi.Tests.UnitTests
             Assert.Equal(FakeModule.Title, spec.Info.Title);
             Assert.Equal(FakeModule.ApiVersion, spec.Info.Version);
             Assert.Equal(FakeModule.TermsOfService, spec.Info.TermsOfService);
-            Assert.Equal(FakeModule.Tags, spec.Tags);
+            Assert.True(FakeModule.Tags.All(t => spec.Tags.Any(
+                               s => t.Name == s.Name &&
+                               t.Description == s.Description &&
+                               t.ExternalDocumentation == s.ExternalDocumentation
+                           )));
         }
 
         [Fact]


### PR DESCRIPTION
@Jaxelr , 

I've made 2 fixes if you don't mind, one for the Tags property and one for the RequestBody-content-schema tree which was not injecting the schema object in the tree.

The new MediaTypeObject should be extended with examples and other properties, as specification defines(noted as TODO for now).

Please note that the Component model does not render nested complex types properly.

George.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
